### PR TITLE
feat: mirror the dragonfly-operator chart

### DIFF
--- a/.github/workflows/app-builder.yaml
+++ b/.github/workflows/app-builder.yaml
@@ -135,7 +135,9 @@ jobs:
           git clone --depth 1 --branch "$tag" "$repository" ./git-src
           mkdir -p ./src
           chart="./src/$(basename "$path")"
-          cp -r "./git-src/${path}" "$chart"
+          # -L: charts may symlink files from outside their own directory, which
+          # would dangle once the chart is copied out of the source tree.
+          cp -rL "./git-src/${path}" "$chart"
           # A git chart isn't packaged with its dependencies, so vendor them before
           # packaging. Register any http(s) dependency repos (helm requires it); OCI
           # (oci://) dependencies resolve directly.

--- a/apps/dragonfly-operator/metadata.yaml
+++ b/apps/dragonfly-operator/metadata.yaml
@@ -1,0 +1,7 @@
+---
+artifactName: dragonfly-operator
+source:
+  git:
+    repository: https://github.com/dragonflydb/dragonfly-operator
+    path: ./charts/dragonfly-operator
+    tag: v1.6.1


### PR DESCRIPTION
Upstream keeps the chart in git only, at `charts/dragonfly-operator` in dragonflydb/dragonfly-operator. There is no OCI chart and no classic Helm repository — `helm show chart oci://ghcr.io/dragonflydb/dragonfly-operator --version v1.6.1` and the `/charts/` variant both answer `not found`.

Hence a git-sourced entry, following `agent-sandbox` and `infisical-standalone-postgres`.

Tag `v1.6.1` matches `version` and `appVersion` in Chart.yaml, so the published artifact carries exactly the chart version.

Building it also needed a fix in `app-builder`: the chart symlinks `dashboards/grafana-dashboard.json` to `../../../monitoring/grafana-dashboard.json`, outside its own directory. `cp -r` copies the symlink as a symlink, which dangles once the chart leaves the source tree, so the build failed before helm ever ran — on `hashFiles('src/**')`. `cp -rL` inlines the file and leaves symlink-free charts untouched.

No upstream request for OCI chart publication has been filed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)