### PR TITLE
feat(langsmith): mirror LangSmith helm chart

### DIFF
--- a/apps/langsmith/metadata.yaml
+++ b/apps/langsmith/metadata.yaml
@@ -1,0 +1,7 @@
+---
+artifactName: langsmith
+source:
+  git:
+    repository: https://github.com/langchain-ai/helm
+    path: ./charts/langsmith
+    tag: langsmith-0.17.0-rc.6


### PR DESCRIPTION
Git-source mirror of the LangSmith chart (no upstream OCI). Publishes to `oci://ghcr.io/astrateam-net/oci-charts/langsmith:langsmith-0.17.0-rc.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)