### PR TITLE
feat: mirror keda + juicefs-csi-driver charts

### DIFF
--- a/apps/juicefs-csi-driver/metadata.yaml
+++ b/apps/juicefs-csi-driver/metadata.yaml
@@ -1,0 +1,6 @@
+---
+artifactName: juicefs-csi-driver
+source:
+  helm:
+    registry: https://juicedata.github.io/charts
+    version: 0.32.3

--- a/apps/keda/metadata.yaml
+++ b/apps/keda/metadata.yaml
@@ -1,0 +1,6 @@
+---
+artifactName: keda
+source:
+  helm:
+    registry: https://kedacore.github.io/charts
+    version: 2.20.2


### PR DESCRIPTION
Dep charts for LangSmith Sandboxes (JuiceFS CSI) + Deployment (KEDA). 🤖 Generated with [Claude Code](https://claude.com/claude-code)