### PR TITLE
fix: strip the chart prefix from a monorepo git tag

### DIFF
--- a/.github/workflows/app-builder.yaml
+++ b/.github/workflows/app-builder.yaml
@@ -64,9 +64,12 @@ jobs:
               echo "chart=$(jq -r --arg fallback "$ARTIFACT_NAME" '.helm.chart // $fallback' <<< "$SOURCE")"
             } >> "$GITHUB_OUTPUT"
           elif jq -e 'has("git")' <<< "$SOURCE" > /dev/null; then
+            # A monorepo tags each chart as <chart>-<version>
+            # (langsmith-0.17.0-rc.6), which helm package rejects as a version.
+            # Drop that prefix; the clone step below reads the tag verbatim.
             {
               echo "type=git"
-              echo "version=$(jq -r '.git.tag' <<< "$SOURCE")"
+              echo "version=$(jq -r --arg name "$ARTIFACT_NAME" '.git.tag | ltrimstr($name + "-")' <<< "$SOURCE")"
               echo "chart=$ARTIFACT_NAME"
             } >> "$GITHUB_OUTPUT"
           else

--- a/.lefthook.toml
+++ b/.lefthook.toml
@@ -1,23 +1,29 @@
 # Local hook config. The reference repository pulls a shared config from
 # `home-operations/.github`; we keep ours self-contained so the repo has no
 # cross-organisation dependency. Tool versions come from .mise/config.toml.
+# lefthook 2 reads jobs as a list, so each one is an array entry.
 
-[pre-commit.jobs.actionlint]
+[[pre-commit.jobs]]
+name = "actionlint"
 glob = ".github/workflows/*.{yml,yaml}"
 run = "actionlint"
 
-[pre-commit.jobs.zizmor]
+[[pre-commit.jobs]]
+name = "zizmor"
 glob = ".github/{workflows,actions}/**/*.{yml,yaml}"
 run = "zizmor --persona regular .github/workflows .github/actions"
 
-[pre-commit.jobs.shellcheck]
+[[pre-commit.jobs]]
+name = "shellcheck"
 glob = "*.sh"
 run = "shellcheck {staged_files}"
 
-[pre-commit.jobs.metadata]
+[[pre-commit.jobs]]
+name = "metadata"
 glob = "apps/*/metadata.yaml"
 run = "./.github/scripts/validate-metadata.sh"
 
-[pre-commit.jobs.oxfmt]
+[[pre-commit.jobs]]
+name = "oxfmt"
 glob = "*.{json,json5}"
 run = "oxfmt --check {staged_files}"


### PR DESCRIPTION
`langchain-ai/helm` tags each chart as `<chart>-<version>`. `helm package --version langsmith-0.17.0-rc.6` fails with `invalid semantic version`, which is why the mirror run on d89ebd5 failed and `ghcr.io/astrateam-net/oci-charts/langsmith` does not exist (`NAME_UNKNOWN` even authenticated).

The prefix is dropped only when the tag starts with the artifact's own name, so `v0.5.5` and `1.21.1` publish verbatim and no existing pin moves. The clone step already reads `.git.tag` verbatim, so the upstream ref is unaffected. Published tag for langsmith becomes `0.17.0-rc.6`.

Also converts `.lefthook.toml` to the list form lefthook 2 expects — the table form failed with `either run, script, or group must be provided for a job` and blocked every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)